### PR TITLE
Added GMP to the graph.

### DIFF
--- a/dependency_graph/generate.py
+++ b/dependency_graph/generate.py
@@ -145,11 +145,15 @@ print '        label = <webthree-helpers dependencies>'
 print '        bgcolor = LemonChiffon'
 print '        "buildinfo"'
 print '        "base"'
+print '        "json_spirit"'
+print '        "scrypt"'
+print '        "secp256k1"'
 print "    }"
 print '    "base" -> "boost"'
 print '    "base" -> "Jsoncpp"'
 print '    "base" -> "LevelDB"'
 print '    "base" -> "pthreads"'
+print '    "secp256k1" -> "gmp"'
 
 processUmbrella('..')
 


### PR DESCRIPTION
Added GMP to the graph.  It was missing, because we only have an indirect dependency onto it, via secp256k1.

Added the three orphaned libraries into the "webthree-helper" cluster.

See new graph at https://github.com/doublethinkco/webthree-umbrella-cross/blob/gh-pages/images/dependency_graph.svg.
