### PR TITLE
Added info for generating  dependancy graph on OSX

### DIFF
--- a/dependency_graph/README.md
+++ b/dependency_graph/README.md
@@ -1,5 +1,5 @@
 
-To generate the `dependancy_graph.svg` the executables `tred` and `dot` are required from the
+To generate the `dependency_graph.svg` the executables `tred` and `dot` are required from the
 [graphviz](http://www.graphviz.org/) package.
 
 ## Installing Graphviz on OSX

--- a/dependency_graph/README.md
+++ b/dependency_graph/README.md
@@ -1,0 +1,10 @@
+
+To generate the `dependancy_graph.svg` the executables `tred` and `dot` are required from the
+[graphviz](http://www.graphviz.org/) package.
+
+## Installing Graphviz on OSX
+
+```
+brew update
+brew install graphviz
+```


### PR DESCRIPTION
It wasn't immediately obvious to me that `tred` and `dot` are from the graphviz package, and these executable are not distributed with OS X.
