### PR TITLE
Added hard-coded edges for the dependencies of AlethZero and AlethOne onto libaleth

### DIFF
--- a/dependency_graph/generate.py
+++ b/dependency_graph/generate.py
@@ -162,6 +162,12 @@ print '    "base" -> "LevelDB"'
 print '    "base" -> "pthreads"'
 print '    "secp256k1" -> "gmp"'
 
+# Hard-coded dependencies for 'libaleth', which doesn't have a UseAleth.cmake
+# to go with it, because the library is only used by the Aleth* applications,
+# and is not exposed to other applications.
+print '    "AlethZero" -> "aleth"'
+print '    "AlethOne" -> "aleth"'
+
 processUmbrella('..')
 
 print "}"


### PR DESCRIPTION
Added hard-coded edges for the dependencies of AlethZero and AlethOne onto libaleth

Those aren't using eth_use(), because that library is not exposed to other applications.
More hard-coding, but it improves our understanding.   Necessary sin!
