### PR TITLE
webthree-umbrella release branch - switch to develop for all sub-modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,32 +1,32 @@
 [submodule "alethzero"]
 	path = alethzero
 	url = https://github.com/ethereum/alethzero
-	branch = release
+	branch = develop
 [submodule "mix"]
 	path = mix
 	url = https://github.com/ethereum/mix
-	branch = release
+	branch = develop
 [submodule "solidity"]
 	path = solidity
 	url = https://github.com/ethereum/solidity
-	branch = release
+	branch = develop
 [submodule "webthree"]
 	path = webthree
 	url = https://github.com/ethereum/webthree
-	branch = release
+	branch = develop
 [submodule "libweb3core"]
 	path = libweb3core
 	url = https://github.com/ethereum/libweb3core
-	branch = release
+	branch = develop
 [submodule "libethereum"]
 	path = libethereum
 	url = https://github.com/ethereum/libethereum
-	branch = release
+	branch = develop
 [submodule "webthree-helpers"]
 	path = webthree-helpers
 	url = https://github.com/ethereum/webthree-helpers
-	branch = release
+	branch = develop
 [submodule "web3.js"]
 	path = web3.js
 	url = https://github.com/ethereum/web3.js
-	branch = release
+	branch = develop


### PR DESCRIPTION
webthree-umbrella release branch - switch to develop for all sub-modules because the release branches which are currently referenced no longer exist.    This change should have the bonus side-effect of making it possible for our umbrella develop and release branches to actually be identical at release points.   Then we need just update versions and flush to release branch at each release point.
