### PR TITLE
Stripped stray AlethOne reference out of OS X DMG generation JSON file.

### DIFF
--- a/res/mac/appdmg.json.in
+++ b/res/mac/appdmg.json.in
@@ -6,7 +6,6 @@
     "contents": [
         { "x": 484, "y": 480, "type": "link", "path": "/Applications" },
         { "x": 290, "y": 250,  "type": "file", "path": "${ETH_ALETHZERO_APP}" },
-        { "x": 160, "y": 250,  "type": "file", "path": "${ETH_ALETHONE_APP}" },
 		{ "x": 678, "y": 250, "type": "file", "path": "${ETH_MIX_APP}" }
     ]
 }


### PR DESCRIPTION
This is the reason why there is still an AlethOne.app showing inside the DMG for cpp-ethereum-1.2.3.
