### PR TITLE
Updated version to 1.2.7:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ include(EthPolicy)
 eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
-project(cpp-ethereum VERSION "1.2.6")
+project(cpp-ethereum VERSION "1.2.7")
 
 include(EthCompilerSettings)
 


### PR DESCRIPTION
Changes since 1.2.6:
- Password locking/unlocking fix
- Reject blocks above max block gas
- Support for FreeBSD builds
- Some tweaks in the usage of EVMJIT
- Fixed warnings in clog() macro which were breaking Arch Linux builds.
- Disable EVMJIT by default
