### PR TITLE
Updated version to 1.2.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ include(EthPolicy)
 eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
-project(cpp-ethereum VERSION "1.2.7")
+project(cpp-ethereum VERSION "1.2.8")
 
 include(EthCompilerSettings)
 


### PR DESCRIPTION
Changes since 1.2.7:
- Correct LICENSE file to show GPLv3 and removed confusing language around MIT.
- Added Solidity Emscripten deployment script using TravisCI.
- Update tests to 64bit block gas limit
- Updated EVMJIT sub-module, to remove accidental use of CMake 3.1 feature.   Back to CMake 3.0+ as min version.
- Fix "mining doesn't return shares" issue introduced as knock-on bug in 1.2.6
- Using c_defaultListenPort constant rather than hardcoded IP port.
- Added test_setChainParams RPC.
- Temporarily forcing OS X binaries to Debug in ethbinaries.sh release process, as workaround for the Heisenbug.
- Moved OpenGL hack into "AND GUI" conditional, to fix openSUSE build break.

Mix-v1.0.5
- Improved handling and error messages for creation of projects in existing folders.
- Fixed documentation link
- (in webthree-helpers) Switched OS X pre-built binaries to Debug to work around crash-at-boot issue.

Solidity-v0.3.5
- Context-dependent path remappings (different modules can use the same library in different versions)
- Type Checking: Dynamic return types were removed when fetching data from external calls, now they are replaced by an "unusable" type.
- Type Checking: Overrides by constructors were considered making a function non-abstract.
