### PR TITLE
Update version to 1.2.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ include(EthPolicy)
 eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
-project(cpp-ethereum VERSION "1.2.8")
+project(cpp-ethereum VERSION "1.2.9")
 
 include(EthCompilerSettings)
 


### PR DESCRIPTION
Changes since 1.2.8:
- Added localized warning-suppressions to work around GCC bug which causing build errors in Debian Jesse
- Do not generate vanity addresses by default
