### PR TITLE
Pull latest commit from webthree

### DIFF
--- a/recreate-cpp-ethereum.sh
+++ b/recreate-cpp-ethereum.sh
@@ -72,6 +72,7 @@ curl https://raw.githubusercontent.com/bobsummerwill/cpp-ethereum/merge_repos/.g
 curl https://raw.githubusercontent.com/bobsummerwill/cpp-ethereum/merge_repos/.gitmodules > $outputDirectory/.gitmodules
 curl https://raw.githubusercontent.com/bobsummerwill/cpp-ethereum/merge_repos/.travis.yml > $outputDirectory/.travis.yml
 curl https://raw.githubusercontent.com/bobsummerwill/cpp-ethereum/merge_repos/appveyor.yml > $outputDirectory/appveyor.yml
+curl https://raw.githubusercontent.com/bobsummerwill/cpp-ethereum/merge_repos/doc/dependency_graph/generate.py > $outputDirectory/doc/dependency_graph/generate.py
 curl https://raw.githubusercontent.com/bobsummerwill/cpp-ethereum/merge_repos/scripts/install_deps.bat > $outputDirectory/scripts/install_deps.bat
 curl https://raw.githubusercontent.com/bobsummerwill/cpp-ethereum/merge_repos/scripts/install_deps.sh > $outputDirectory/scripts/install_deps.sh
 curl https://raw.githubusercontent.com/bobsummerwill/cpp-ethereum/merge_repos/scripts/release.bat > $outputDirectory/scripts/release.bat


### PR DESCRIPTION
Pull latest commit from webthree:
- Fix macOS build in UnixSocketServer.cpp. This break was a knock-on from the previous change to this file "fix eth crashing on rpc reconnection"

Recreate script now grabs dependency graph from cpp-ethereum, because it has diverged
